### PR TITLE
Fixed invalid css property 'animate-delay'

### DIFF
--- a/style.css
+++ b/style.css
@@ -4011,7 +4011,7 @@ sup {
 }
 
 .animate-delay {
-  animate-delay: 100ms;
+  animation-delay: 100ms;
 }
 
 .main-slider-text {


### PR DESCRIPTION
Animate-delay property given to animate-delay class is invalid. Changed it to animation-delay which is a valid property.

[No change detected in website]